### PR TITLE
Set a default worker username.

### DIFF
--- a/worker.json
+++ b/worker.json
@@ -22,7 +22,7 @@
 		},
 		"virtualMachineUsername": {
 			"type": "string",
-			"defaultValue": "",
+			"defaultValue": "lgtm-admin",
 			"metadata": {
 				"description": "Username for SSH access to the virtual machine. You can leave this blank and configure SSH access to the virtual machine later through the Azure \"reset password\" feature."
 			}


### PR DESCRIPTION
We give this a default value of `lgtm-admin` for the controller. We should probably just do the same for the workers.